### PR TITLE
Allow bridge to different JSON key name

### DIFF
--- a/json_document/bridge.py
+++ b/json_document/bridge.py
@@ -42,9 +42,18 @@ def fragment(func):
         def foo(self):
             return self['foo']
     """
+    name = func.__name__ if callable(func) else func
+
     def _get(self):
-        return self[func.__name__]
-    return property(_get, None, None, func.__doc__)
+        return self[name]
+
+    def wrapper(func):
+        return property(_get, None, None, func.__doc__)
+
+    if callable(func):
+        return property(_get, None, None, func.__doc__)
+    else:
+        return wrapper
 
 
 def readonly(func):
@@ -61,9 +70,18 @@ def readonly(func):
         def foo(self):
             return self['foo'].value
     """
+    name = func.__name__ if callable(func) else func
+
     def _get(self):
-        return self[func.__name__].value
-    return property(_get, None, None, func.__doc__)
+        return self[name].value
+
+    def wrapper(func):
+        return property(_get, None, None, func.__doc__)
+
+    if callable(func):
+        return property(_get, None, None, func.__doc__)
+    else:
+        return wrapper
 
 
 def readwrite(func):
@@ -86,15 +104,23 @@ def readwrite(func):
         def foo(self, new_value):
             return self['foo'] = new_value
     """
+    name = func.__name__ if callable(func) else func
+
     def _get(self):
-        return self[func.__name__].value
+        return self[name].value
 
     def _set(self, new_value):
         # XXX: Dear reader, see what __setitem__ does to understand why we
         # don't assign to .value
-        self[func.__name__] = new_value
+        self[name] = new_value
 
     def _del(self):
-        del self[func.__name__]
+        del self[name]
 
-    return property(_get, _set, _del, func.__doc__)
+    def wrapper(func):
+        return property(_get, _set, _del, func.__doc__)
+
+    if callable(func):
+        return property(_get, _set, _del, func.__doc__)
+    else:
+        return wrapper

--- a/json_document/tests/test_bridge.py
+++ b/json_document/tests/test_bridge.py
@@ -1,0 +1,66 @@
+# This file is part of json-document
+#
+# json-document is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation
+#
+# json-document is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with json-document.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for bridge decorators."""
+
+from unittest2 import TestCase
+
+from json_document import bridge
+from json_document.document import Document, DocumentFragment
+
+
+class DecoratorHyphenTests(TestCase):
+    """Test automatic hyphen to underscore translation."""
+
+    class TestDocument(Document):
+
+        @bridge.fragment('foo-bar-fragment')
+        def foo_bar_fragment(self):
+            """Fragment."""
+            pass
+
+        @bridge.readonly('foo-bar-readonly')
+        def foo_bar_readonly(self):
+            """Read-only fragment."""
+            pass
+
+        @bridge.readwrite('foo-bar-readwrite')
+        def foo_bar_readwrite(self):
+            """Read-write fragment."""
+            pass
+
+    def setUp(self):
+        super(DecoratorHyphenTests, self).setUp()
+        self.doc = self.TestDocument({})
+
+    def test_hyphen_fragment(self):
+        obj = object()
+        self.doc['foo-bar-fragment'] = obj
+        self.assertIsInstance(self.doc.foo_bar_fragment, DocumentFragment)
+        self.assertIs(self.doc.foo_bar_fragment.value, obj)
+        self.assertEqual(self.TestDocument.foo_bar_fragment.__doc__, 'Fragment.')
+
+    def test_hyphen_readonly(self):
+        obj = object()
+        self.doc['foo-bar-readonly'] = obj
+        self.assertIs(self.doc.foo_bar_readonly, obj)
+        self.assertEqual(self.TestDocument.foo_bar_readonly.__doc__,
+                         'Read-only fragment.')
+
+    def test_hyphen_readwrite(self):
+        obj = object()
+        self.doc['foo-bar-readwrite'] = obj
+        self.assertIs(self.doc.foo_bar_readwrite, obj)
+        self.assertEqual(self.TestDocument.foo_bar_readwrite.__doc__,
+                         'Read-write fragment.')


### PR DESCRIPTION
Accept a parameter to bridge decorators for the key name to
access in the JSON instead of the property name.

Allows mapping to keys which are illegal Python property names,
such as `foo-bar`.
